### PR TITLE
fix spacebrew.js version in admin example

### DIFF
--- a/spacebrew_admin/index.html
+++ b/spacebrew_admin/index.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="css/style.css" type="text/css" media="screen" charset="utf-8" />
 
     <script type="text/javascript" src="js/jq.js"></script>
-	<script type="text/javascript" src="js/sb-1.4.0.js"></script>
+	<script type="text/javascript" src="js/sb-1.4.1.js"></script>
 	<script type="text/javascript" src="js/sb-admin-0.1.4.js"></script>
     <script type="text/javascript">
 


### PR DESCRIPTION
Load the correct version of the spacebrew.js library in the admin example.

The admin example is trying to load version 1.4.0 even though version 1.4.1 is included in the js folder.