### PR TITLE
prevent reconnect using the options object

### DIFF
--- a/library/sb-1.4.1.js
+++ b/library/sb-1.4.1.js
@@ -147,7 +147,7 @@ Spacebrew.Client = function( server, name, description, options ){
 	if ( window ){
 		this.debug = (window.getQueryString("debug") === "true" ? true : (options.debug || false));
 	}
-	this.reconnect = options.reconnect || true;
+	this.reconnect = typeof options.reconnect === "boolean" ? options.reconnect : true;
 	this.reconnect_timer = undefined;
 
 	this.sendRateCapped = options.capSendRate === undefined ? false : options.capSendRate;


### PR DESCRIPTION
Hi,

I just noticed that it's currently impossible to prevent the client from reconnecting using the options object, e.g: `` {reconnect: false}``.

This is because in the JavaScript library, ``this.reconnect`` is always set to ``true`` if ``options.reconnect`` is a [falsy](http://www.sitepoint.com/javascript-truthy-falsy/#post-11126) value.

However, both *undefined* and *false* are falsy values, so there's no way of setting reconnect to ``false``.

This issue can be fixed by doing a type check instead.

