### PR TITLE
add onerror handler and autoreconnect on error

### DIFF
--- a/library/sb-1.4.1.js
+++ b/library/sb-1.4.1.js
@@ -236,6 +236,7 @@ Spacebrew.Client.prototype.connect = function(){
 		this.socket.onopen		= this._onOpen.bind(this);
 		this.socket.onmessage	= this._onMessage.bind(this);
 		this.socket.onclose		= this._onClose.bind(this);
+		this.socket.onerror   = this._onError.bind(this);
 
 	} catch(e){
 		this._isConnected = false;
@@ -572,6 +573,35 @@ Spacebrew.Client.prototype._onClose = function() {
 
 
 	this.onClose();
+};
+
+/**
+* Called on WebSocket error
+* @private
+* @memberOf Spacebrew.Client
+*/
+Spacebrew.Client.prototype._onError = function(e) {
+ var self = this;
+ console.log("[_onError:Spacebrew] Spacebrew connection error");
+
+ this._isConnected = false;
+ if (this.admin.active) {
+	 this.admin.remoteAddress = undefined;
+ }
+
+ // if reconnect functionality is activated set interval timer if connection dies
+ if (this.reconnect && !this.reconnect_timer) {
+	 console.log("[_onError:Spacebrew] setting up reconnect timer");
+	 this.reconnect_timer = setInterval(function () {
+			 if (self.isConnected !== false) {
+				 self.connect();
+				 console.log("[reconnect:Spacebrew] attempting to reconnect to spacebrew");
+			 }
+		 }, 5000);
+ }
+
+
+ this.onError(e);
 };
 
 /**

--- a/library/sb-1.4.1.js
+++ b/library/sb-1.4.1.js
@@ -276,6 +276,13 @@ Spacebrew.Client.prototype.onOpen = function( name, value ){};
 Spacebrew.Client.prototype.onClose = function( name, value ){};
 
 /**
+ * Override in your app to receive on close event for connection
+ * @memberOf Spacebrew.Client
+ * @public
+ */
+Spacebrew.Client.prototype.onError = function( name, value ){};
+
+/**
  * Override in your app to receive "range" messages, e.g. sb.onRangeMessage = yourRangeFunction
  * @param  {String} name  Name of incoming route
  * @param  {Number} value The data being provided
@@ -578,6 +585,7 @@ Spacebrew.Client.prototype._onClose = function() {
 /**
 * Called on WebSocket error
 * @private
+* @param  {Object} e
 * @memberOf Spacebrew.Client
 */
 Spacebrew.Client.prototype._onError = function(e) {


### PR DESCRIPTION
Needed this in a recent project. Prior to this change, if a websocket error happened, I didn't have any scope in which I could catch it let alone specify a handler. This hooks in a handler and does auto-reconnect if that's enabled.